### PR TITLE
Fix exception string so project can build on older PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: php
 
 php:
+    - 5.4
+    - 5.5
+    - 5.6
     - 7.0
+    - hhvm
     - nightly
 
 before_script:

--- a/tests/FlatBuffersTest.php
+++ b/tests/FlatBuffersTest.php
@@ -146,7 +146,7 @@ class FlatBuffersTest extends PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\Exception', "FlatBuffers: cannot grow buffer beyond 2 gigabytes");
 
-        $byteBuffer = Mockery::mock('overload:' . ByteBuffer::class);
+        $byteBuffer = Mockery::mock('overload: FlatBuffers\ByteBuffer');
         $byteBuffer->shouldReceive('capacity')
             ->andReturn((float)2e+9);
 
@@ -160,7 +160,7 @@ class FlatBuffersTest extends PHPUnit_Framework_TestCase
      */
     public function testPutBoolAddsCharacterToBuffer()
     {
-        $byteBuffer = Mockery::mock('overload:' . ByteBuffer::class);
+        $byteBuffer = Mockery::mock('overload: FlatBuffers\ByteBuffer');
         $byteBuffer->shouldReceive('put')
             ->with(0, chr(1));
 
@@ -180,7 +180,7 @@ class FlatBuffersTest extends PHPUnit_Framework_TestCase
      */
     public function testPutSbyteAddsCharacterToBuffer()
     {
-        $byteBuffer = Mockery::mock('overload:' . ByteBuffer::class);
+        $byteBuffer = Mockery::mock('overload: FlatBuffers\ByteBuffer');
         $byteBuffer->shouldReceive('put')
             ->with(0, chr(35));
 

--- a/tests/FlatBuffersTest.php
+++ b/tests/FlatBuffersTest.php
@@ -7,12 +7,12 @@ use FlatBuffers\Constants;
 class StringWrapper extends Table implements Constants
 {
 
-	private $fbb;
+    private $fbb;
 
-	public function __construct(FlatBufferBuilder $flatBufferBuilder)
-	{
-		$this->fbb = $flatBufferBuilder;
-	}
+    public function __construct(FlatBufferBuilder $flatBufferBuilder)
+    {
+        $this->fbb = $flatBufferBuilder;
+    }
 
     public function tearDown()
     {
@@ -21,69 +21,68 @@ class StringWrapper extends Table implements Constants
 
 
     public function init(ByteBuffer $byteBuffer)
-	{
-		$this->bb = $byteBuffer;
-		$this->bb_pos = $this->bb->getInt($this->bb->getPosition()) + $this->bb->getPosition();
-
-		return $this;
-	}
-
-	public function getString($slot = 0)
     {
-		$vtable_offset = self::SIZEOF_INT + ($slot * 2);
+        $this->bb = $byteBuffer;
+        $this->bb_pos = $this->bb->getInt($this->bb->getPosition()) + $this->bb->getPosition();
 
-		$vtable = $this->bb_pos - $this->bb->getInt($this->bb_pos);
-
-		$offset = $vtable_offset < $this->bb->getShort($vtable) ? $this->bb->getShort($vtable + $vtable_offset) : 0;
-
-		$offset += $this->bb_pos + $this->bb->getInt($offset + $this->bb_pos);
-		$len = $this->bb->getInt($offset);
-		$startPos = $offset + self::SIZEOF_INT;
-		$_string = substr($this->bb->_buffer, $startPos, $len);
-
-		return ($offset != 0 ? $_string : null);
+        return $this;
     }
 
-	public function createString($value)
-	{
-		return $this->fbb->createString($value);
-	}
+    public function getString($slot = 0)
+    {
+        $vtable_offset = self::SIZEOF_INT + ($slot * 2);
 
-	public function addString($slot, $str)
-	{
-		$this->fbb->addOffsetX($slot, $str, 0);
-	}
+        $vtable = $this->bb_pos - $this->bb->getInt($this->bb_pos);
+
+        $offset = $vtable_offset < $this->bb->getShort($vtable) ? $this->bb->getShort($vtable + $vtable_offset) : 0;
+
+        $offset += $this->bb_pos + $this->bb->getInt($offset + $this->bb_pos);
+        $len = $this->bb->getInt($offset);
+        $startPos = $offset + self::SIZEOF_INT;
+        $_string = substr($this->bb->_buffer, $startPos, $len);
+
+        return ($offset != 0 ? $_string : null);
+    }
+
+    public function createString($value)
+    {
+        return $this->fbb->createString($value);
+    }
+
+    public function addString($slot, $str)
+    {
+        $this->fbb->addOffsetX($slot, $str, 0);
+    }
 
     public function createArrayOfStringVector(array $data)
     {
         $this->fbb->startVector(4, count($data), 4);
-        for ($i = count($data) - 1; $i >= 0; $i--)
-		{
+        for ($i = count($data) - 1; $i >= 0; $i--) {
             $this->fbb->addOffset($data[$i]);
         }
 
         return $this->fbb->endVector();
     }
 
-	public function dataBuffer()
-	{
-		return $this->fbb->dataBuffer();
-	}
+    public function dataBuffer()
+    {
+        return $this->fbb->dataBuffer();
+    }
 
-	public function startObject($numfields)
-	{
-		$this->fbb->startObject($numfields);
-	}
+    public function startObject($numfields)
+    {
+        $this->fbb->startObject($numfields);
+    }
 
-	public function endObject()
-	{
-		return $this->fbb->endObject();
-	}
+    public function endObject()
+    {
+        return $this->fbb->endObject();
+    }
 
-	public function finish($root_table, $identifier = NULL)
-	{
-		$this->fbb->finish($root_table, $identifier);
-	}
+    public function finish($root_table, $identifier = NULL)
+    {
+        $this->fbb->finish($root_table, $identifier);
+    }
 
 }
 
@@ -91,34 +90,34 @@ class StringWrapper extends Table implements Constants
 class FlatBuffersTest extends PHPUnit_Framework_TestCase
 {
 
-	public function testCreateString()
-	{
-		$flatBufferBuilder = new FlatBufferBuilder(1);
-		$stringWrapper = new StringWrapper($flatBufferBuilder);
+    public function testCreateString()
+    {
+        $flatBufferBuilder = new FlatBufferBuilder(1);
+        $stringWrapper = new StringWrapper($flatBufferBuilder);
 
-		$firstText = $stringWrapper->createString('first_value');
-		$secondText = $stringWrapper->createString('second_value');
+        $firstText = $stringWrapper->createString('first_value');
+        $secondText = $stringWrapper->createString('second_value');
 
-		$stringWrapper->startObject(25);
-			$stringWrapper->addString(2, $firstText);
-			$stringWrapper->addString(3, $secondText);
-		$stringWrapper->finish($stringWrapper->endObject());
+        $stringWrapper->startObject(25);
+        $stringWrapper->addString(2, $firstText);
+        $stringWrapper->addString(3, $secondText);
+        $stringWrapper->finish($stringWrapper->endObject());
 
-		$stringWrapper->init($stringWrapper->dataBuffer());
+        $stringWrapper->init($stringWrapper->dataBuffer());
 
-		$this->assertEquals('first_value', $stringWrapper->getString(2));
-		$this->assertEquals('second_value', $stringWrapper->getString(3));
-	}
+        $this->assertEquals('first_value', $stringWrapper->getString(2));
+        $this->assertEquals('second_value', $stringWrapper->getString(3));
+    }
 
-	public function testReadDataFromFile()
-	{
-		$bytes = file_get_contents(dirname((__FILE__)).DIRECTORY_SEPARATOR.'test.data.mon');
+    public function testReadDataFromFile()
+    {
+        $bytes = file_get_contents(dirname((__FILE__)) . DIRECTORY_SEPARATOR . 'test.data.mon');
 
-		$flatBufferBuilder = new FlatBufferBuilder(1);
-		$stringWrapper = new StringWrapper($flatBufferBuilder);
+        $flatBufferBuilder = new FlatBufferBuilder(1);
+        $stringWrapper = new StringWrapper($flatBufferBuilder);
 
-		$this->assertEquals($flatBufferBuilder->bb->_buffer, $stringWrapper->dataBuffer()->data());
-	}
+        $this->assertEquals($flatBufferBuilder->bb->_buffer, $stringWrapper->dataBuffer()->data());
+    }
 
     public function lessThanOneDataProvider()
     {
@@ -145,7 +144,7 @@ class FlatBuffersTest extends PHPUnit_Framework_TestCase
      */
     public function testPrepThrowsExceptionWhenBufferGrowsBeyond2GB()
     {
-        $this->setExpectedException(\Exception::class, "FlatBuffers: cannot grow buffer beyond 2 gigabytes");
+        $this->setExpectedException('\Exception', "FlatBuffers: cannot grow buffer beyond 2 gigabytes");
 
         $byteBuffer = Mockery::mock('overload:' . ByteBuffer::class);
         $byteBuffer->shouldReceive('capacity')
@@ -174,7 +173,7 @@ class FlatBuffersTest extends PHPUnit_Framework_TestCase
         $flatBufferBuilder = new FlatBufferBuilder(1);
         $flatBufferBuilder->putBool(false);
     }
-    
+
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled


### PR DESCRIPTION
Fix the build, `::class` wasn't available in older versions.
